### PR TITLE
update youtube-transcript-api

### DIFF
--- a/src/youtube_video.py
+++ b/src/youtube_video.py
@@ -14,6 +14,12 @@ from youtube_transcript_api import YouTubeTranscriptApi
 from src.logger import Logger
 
 
+PROXIES = {
+    'http': "socks5://127.0.0.1:9050",
+    'https': "socks5://127.0.0.1:9050",
+}
+
+
 class YouTubeVideo(Logger):
     def __init__(self, url):
         self.url = url
@@ -218,7 +224,7 @@ class YouTubeVideo(Logger):
         return chapters
     
 
-    def _get_transcript(self, languages=("en", "de")) -> list[dict]:
+    def _get_transcript(self, languages=["en", "de"]) -> list[dict]:
         """
         Retrieves the transcript of a YouTube video and converts it to a timestamped format.
         Args:
@@ -233,11 +239,15 @@ class YouTubeVideo(Logger):
         video_id = self.url.split('=')[-1]
 
         try:
-            data = YouTubeTranscriptApi.get_transcript(video_id, languages=languages)
-            if not data:
+            transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+            transcript = transcript_list.find_generated_transcript(['de', 'en'])
+            fetched_transcript = transcript.fetch()
+            transcript = fetched_transcript.to_raw_data()
+
+            if not transcript:
                 self.logger.error(f"No transcript available for this video.")
                 return None
-            timestamped_data = self._convert_transcript_to_timedelta(data)
+            timestamped_data = self._convert_transcript_to_timedelta(transcript)
             self.logger.info(f"Successfully retrieved transcript")
             return timestamped_data
         

--- a/summarizer_ui.py
+++ b/summarizer_ui.py
@@ -112,9 +112,13 @@ if 'youtube_video' in st.session_state and st.session_state.youtube_video:
             st.write(chapter)
 
     if summary_entire_video_result:
+        st.write(f"### {st.session_state.youtube_video.title}")
+        st.write(f"#### by {st.session_state.youtube_video.channel}")
         st.write("Summary of Entire Video:")
         st.write(summary_entire_video_result)
 
     if summary_one_sentence_result:
+        st.write(f"### {st.session_state.youtube_video.title}")
+        st.write(f"#### by {st.session_state.youtube_video.channel}")
         st.write("One Sentence Summary:")
         st.write(summary_one_sentence_result)

--- a/tests/test_youtube_video.py
+++ b/tests/test_youtube_video.py
@@ -6,6 +6,8 @@ import unittest
 # User-defined Imports
 from src.youtube_video import YouTubeVideo
 from src.logger import Logger
+import unittest
+from unittest.mock import patch, MagicMock
 
 
 # Mock the YouTubeVideo class
@@ -192,6 +194,60 @@ class Test_YouTubeVideo_extract_chapters(unittest.TestCase):
         mock.description = description_example
         function_output = mock._extract_chapters()
         self.assertEqual(function_output, expected_output)
+
+
+class Test_YouTubeVideo_get_transcript(unittest.TestCase):
+    def setUp(self):
+        self.video = YouTubeVideo("https://youtube.com/watch?v=dQw4w9WgXcQ")
+        self.video.logger = MagicMock()
+        self.video.soup = MagicMock()
+        self.video.description = "desc"
+        self.video.chapters_available = False
+
+    @patch("src.youtube_video.YouTubeTranscriptApi")
+    def test_get_transcript_success(self, mock_api):
+        # Mock transcript data
+        transcript_data = [
+            {'start': 0.0, 'duration': 5.0, 'text': 'Hello'},
+            {'start': 5.0, 'duration': 4.0, 'text': 'World'}
+        ]
+        mock_transcript = MagicMock()
+        mock_transcript.fetch.return_value = transcript_data
+        mock_transcript_list = MagicMock()
+        mock_transcript_list.find_transcript.return_value = mock_transcript
+        mock_api.list_transcripts.return_value = mock_transcript_list
+
+        result = self.video._get_transcript(languages=("en",))
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0]['text'], 'Hello')
+        self.assertIn('timestamp', result[0])
+        self.assertEqual(result[1]['text'], 'World')
+        self.assertIn('timestamp', result[1])
+
+    @patch("src.youtube_video.YouTubeTranscriptApi")
+    def test_get_transcript_no_data(self, mock_api):
+        mock_transcript = MagicMock()
+        mock_transcript.fetch.return_value = []
+        mock_transcript_list = MagicMock()
+        mock_transcript_list.find_transcript.return_value = mock_transcript
+        mock_api.list_transcripts.return_value = mock_transcript_list
+
+        result = self.video._get_transcript(languages=("en",))
+        self.assertIsNone(result)
+
+    @patch("src.youtube_video.YouTubeTranscriptApi")
+    def test_get_transcript_exception(self, mock_api):
+        mock_api.list_transcripts.side_effect = Exception("API error")
+        result = self.video._get_transcript(languages=("en",))
+        self.assertIsNone(result)
+        
+    def test_get_transcript_debug_output(self):
+        # Use a real YouTubeVideo object, but override _get_transcript to return a known value for debugging
+        video = YouTubeVideo("https://youtube.com/watch?v=dQw4w9WgXcQ")
+        result = video._get_transcript(languages=("en",))
+        print("DEBUG transcript result:", result)
+        self.assertIsInstance(result, list)
+        self.assertEqual(result[0]['text'], '[Music]')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
See new FetchedTranscript: https://github.com/jdepoix/youtube-transcript-api/blob/master/README.md

# List Available Transcripts

If you want to list all transcripts available for a given video, you can use the following code:

```python
from youtube_transcript_api import YouTubeTranscriptApi

ytt_api = YouTubeTranscriptApi()
transcript_list = ytt_api.list_transcripts(video_id)
```

This returns a `TranscriptList` object, which is iterable and provides methods to filter transcripts by specific languages and types. For example:

```python
transcript = transcript_list.find_transcript(['de', 'en'])
```

By default, this module prefers **manually created transcripts** over **automatically generated ones**, if both are available in the requested language.

If you want to explicitly choose a transcript type, you can use:

```python
# Filter for manually created transcripts
transcript = transcript_list.find_manually_created_transcript(['de', 'en'])

# Or automatically generated ones
transcript = transcript_list.find_generated_transcript(['de', 'en'])
```

All of these methods return a `Transcript` object, which contains metadata about the transcript:

```python
print(
    transcript.video_id,
    transcript.language,
    transcript.language_code,
    transcript.is_generated,           # True if generated by YouTube
    transcript.is_translatable,        # True if translation is supported
    transcript.translation_languages   # List of language codes the transcript can be translated to
)
```

To fetch the actual transcript data, use the `.fetch()` method:

```python
transcript_data = transcript.fetch()
```

This returns a `FetchedTranscript` object, just like `YouTubeTranscriptApi.fetch(video_id)` does.
